### PR TITLE
Fix/endpoint get inboundorder

### DIFF
--- a/src/main/java/br/com/meli/PIFrescos/dtos/BatchDTO.java
+++ b/src/main/java/br/com/meli/PIFrescos/dtos/BatchDTO.java
@@ -1,4 +1,4 @@
-package br.com.meli.PIFrescos.models.dto;
+package br.com.meli.PIFrescos.dtos;
 
 import br.com.meli.PIFrescos.models.Batch;
 import br.com.meli.PIFrescos.models.Product;
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author Marcelo Leite
+ * @author Felipe Myose
  * */
 @Data
 @NoArgsConstructor

--- a/src/main/java/br/com/meli/PIFrescos/dtos/BatchDTO.java
+++ b/src/main/java/br/com/meli/PIFrescos/dtos/BatchDTO.java
@@ -1,0 +1,47 @@
+package br.com.meli.PIFrescos.models.dto;
+
+import br.com.meli.PIFrescos.models.Batch;
+import br.com.meli.PIFrescos.models.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Marcelo Leite
+ * */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BatchDTO {
+
+  private Float currentTemperature;
+  private Float minimumTemperature;
+  private Integer initialQuantity;
+  private Integer currentQuantity;
+  private LocalDate manufacturingDate;
+  private LocalDate dueDate;
+
+  private Integer productId;
+
+  public static Batch convert(BatchDTO dto) {
+    return Batch.builder()
+            .currentTemperature(dto.getCurrentTemperature())
+            .minimumTemperature(dto.getMinimumTemperature())
+            .initialQuantity(dto.getInitialQuantity())
+            .currentQuantity(dto.getCurrentQuantity())
+            .manufacturingDate(dto.getManufacturingDate())
+            .dueDate(dto.getDueDate())
+            .product(new Product(dto.getProductId(),null,null,null))
+            .build();
+  }
+
+  public static List<Batch> convert(List<BatchDTO> dtos) {
+    return dtos.stream().map(batchDTO -> convert(batchDTO)).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/br/com/meli/PIFrescos/dtos/InboundOrderDTO.java
+++ b/src/main/java/br/com/meli/PIFrescos/dtos/InboundOrderDTO.java
@@ -1,6 +1,5 @@
 package br.com.meli.PIFrescos.dtos;
 
-import br.com.meli.PIFrescos.models.Batch;
 import br.com.meli.PIFrescos.models.InboundOrder;
 import br.com.meli.PIFrescos.models.Section;
 import lombok.AllArgsConstructor;
@@ -21,10 +20,11 @@ public class InboundOrderDTO {
 
     private LocalDate orderDate;
     private Section section;
-    private List<Batch> batchStock;
+    private List<BatchDTO> batchStock;
 
     public static InboundOrder convert(InboundOrderDTO dto) {
-        return new InboundOrder(null, dto.getOrderDate(), dto.getSection(), dto.getBatchStock());
+        return new InboundOrder(null, dto.getOrderDate(), dto.getSection(),
+                BatchDTO.convert(dto.getBatchStock()));
     }
 
 }

--- a/src/test/java/br/com/meli/PIFrescos/service/InboundOrderServiceTest.java
+++ b/src/test/java/br/com/meli/PIFrescos/service/InboundOrderServiceTest.java
@@ -2,11 +2,12 @@ package br.com.meli.PIFrescos.service;
 
 import br.com.meli.PIFrescos.models.Batch;
 import br.com.meli.PIFrescos.models.InboundOrder;
+import br.com.meli.PIFrescos.models.Product;
 import br.com.meli.PIFrescos.models.Section;
 import br.com.meli.PIFrescos.models.StorageType;
 import br.com.meli.PIFrescos.models.Warehouse;
 import br.com.meli.PIFrescos.repository.InboundOrderRepository;
-import br.com.meli.PIFrescos.service.interfaces.ISectionService;
+import br.com.meli.PIFrescos.repository.ProductRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +28,9 @@ import static org.mockito.Mockito.verify;
 class InboundOrderServiceTest {
 
     @Mock
+    private ProductRepository productRepository;
+
+    @Mock
     private InboundOrderRepository inboundOrderRepository;
 
     @Mock
@@ -35,10 +39,12 @@ class InboundOrderServiceTest {
     @InjectMocks
     private InboundOrderService inboundOrderService;
 
-    Warehouse warehouse = new Warehouse();
-    Section section = new Section(); InboundOrder inboundOrder = new InboundOrder();
-    Batch batch1 = new Batch();
-    Batch batch2 = new Batch();
+    private Warehouse warehouse = new Warehouse();
+    private Section section = new Section(); InboundOrder inboundOrder = new InboundOrder();
+    private Batch batch1 = new Batch();
+    private Batch batch2 = new Batch();
+    private Product product1 = new Product();
+    private Product product2 = new Product();
 
     @BeforeEach
     void setup() {
@@ -46,6 +52,8 @@ class InboundOrderServiceTest {
         section = new Section(1, StorageType.FRESH, 10, 0, warehouse);
         batch1.setCurrentQuantity(2);
         batch2.setCurrentQuantity(3);
+        batch1.setProduct(new Product());
+        batch2.setProduct(new Product());
         inboundOrder = new InboundOrder(1, LocalDate.now(), section, Arrays.asList(batch1, batch2));
     }
 
@@ -54,6 +62,7 @@ class InboundOrderServiceTest {
         Integer sectionCode = section.getSectionCode();
         Integer quantity = inboundOrder.getBatchStock().stream().mapToInt(batch -> batch.getCurrentQuantity()).sum();
 
+        Mockito.when(productRepository.findById(null)).thenReturn(java.util.Optional.ofNullable(product1));
         Mockito.when(sectionService.updateCapacity(sectionCode, quantity)).thenReturn(5);
         Mockito.when(inboundOrderRepository.save(inboundOrder)).thenReturn(inboundOrder);
 


### PR DESCRIPTION
When saving a new InboundOrder, we need to check before if the products exist and we can fit in sector.
Also, since we only the product id is known, we need to set the products values and the inboundorder in the batch:
- for product, get it values from product repository;
- for inboundorder number, it is necessary to save to generate this value. Then, after setting it in the Batch, save it again to update.