### PR TITLE
Fix/purchaseorderfrom cartlist attribute

### DIFF
--- a/src/main/java/br/com/meli/PIFrescos/controller/PurchaseOrderController.java
+++ b/src/main/java/br/com/meli/PIFrescos/controller/PurchaseOrderController.java
@@ -2,9 +2,11 @@ package br.com.meli.PIFrescos.controller;
 
 import br.com.meli.PIFrescos.controller.dtos.OrderProductDTO;
 import br.com.meli.PIFrescos.controller.dtos.TotalPriceDTO;
+import br.com.meli.PIFrescos.controller.forms.ProductCartForm;
 import br.com.meli.PIFrescos.controller.forms.PurchaseOrderForm;
 import br.com.meli.PIFrescos.models.Batch;
 import br.com.meli.PIFrescos.models.Product;
+import br.com.meli.PIFrescos.models.ProductsCart;
 import br.com.meli.PIFrescos.models.PurchaseOrder;
 import br.com.meli.PIFrescos.service.PurchaseOrderService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,9 +33,9 @@ public class PurchaseOrderController {
      */
 
     @PostMapping("")
-    public ResponseEntity<TotalPriceDTO> postOrder(@RequestBody PurchaseOrderForm form) {
+    public ResponseEntity<TotalPriceDTO> postOrder(@RequestBody PurchaseOrderForm purchaseOrderForm){
 
-        PurchaseOrder order = form.convertToEntity();
+        PurchaseOrder order = PurchaseOrderForm.convertToEntity(purchaseOrderForm);
         PurchaseOrder savedOrder = service.save(order);
 
         BigDecimal totalPrice = service.calculateTotalPrice(savedOrder);

--- a/src/main/java/br/com/meli/PIFrescos/controller/forms/ProductCartForm.java
+++ b/src/main/java/br/com/meli/PIFrescos/controller/forms/ProductCartForm.java
@@ -20,8 +20,9 @@ public class ProductCartForm {
     /**
      * Converter a compra do usuario para o ProductsCart, o qual contem toda informaçao necessaria.
      * Muitas informaçoes são desconhecidas - buscar estes dados na camada de serviço.
-      * @param productCartForm
+     * @param productCartForm
      * @return productCart com valores vazios
+     * @author Felipe Myose
      */
     public static ProductsCart convert(ProductCartForm productCartForm) {
 

--- a/src/main/java/br/com/meli/PIFrescos/controller/forms/ProductCartForm.java
+++ b/src/main/java/br/com/meli/PIFrescos/controller/forms/ProductCartForm.java
@@ -1,0 +1,37 @@
+package br.com.meli.PIFrescos.controller.forms;
+
+import br.com.meli.PIFrescos.models.Batch;
+import br.com.meli.PIFrescos.models.Product;
+import br.com.meli.PIFrescos.models.ProductsCart;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class ProductCartForm {
+
+    private Integer batchId;
+    private Integer quantity;
+
+    private String productName; // podemos usar o productName no lugar do id
+
+    /**
+     * Converter a compra do usuario para o ProductsCart, o qual contem toda informaçao necessaria.
+     * Muitas informaçoes são desconhecidas - buscar estes dados na camada de serviço.
+      * @param productCartForm
+     * @return productCart com valores vazios
+     */
+    public static ProductsCart convert(ProductCartForm productCartForm) {
+
+        Batch batch = new Batch();
+        batch.setBatchNumber(productCartForm.getBatchId());
+        ProductsCart productsCart = new ProductsCart();
+
+        productsCart.setBatch(batch);
+        productsCart.setQuantity(productCartForm.getQuantity());
+
+        return  productsCart;
+    }
+}

--- a/src/main/java/br/com/meli/PIFrescos/controller/forms/PurchaseOrderForm.java
+++ b/src/main/java/br/com/meli/PIFrescos/controller/forms/PurchaseOrderForm.java
@@ -4,24 +4,39 @@ import br.com.meli.PIFrescos.models.OrderStatus;
 import br.com.meli.PIFrescos.models.ProductsCart;
 import br.com.meli.PIFrescos.models.PurchaseOrder;
 import br.com.meli.PIFrescos.models.User;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
+@Getter
+@Setter
 public class PurchaseOrderForm {
 
     @NotNull(message = "User field can't be empty")
     @ManyToOne
-    private User user;
+    private Integer userId;
     private LocalDate date;
     @NotNull(message = "OrderStatus field can't be empty")
     private OrderStatus orderStatus;
     @NotNull(message = "ProductsCart list field can't be empty")
-    private List<ProductsCart> cartList;
+    private List<ProductCartForm> cartList;
 
-    public PurchaseOrder convertToEntity(){
-        return new PurchaseOrder(null, user, date, orderStatus, cartList);
+    public static PurchaseOrder convertToEntity(PurchaseOrderForm purchaseOrderForm){
+        User user = new User();
+        user.setId(purchaseOrderForm.getUserId());
+        PurchaseOrder purchaseOrder = new PurchaseOrder();
+        purchaseOrder.setUser(user);
+        purchaseOrder.setOrderStatus(OrderStatus.OPENED);
+        purchaseOrder.setDate(LocalDate.now());
+        purchaseOrder.setCartList(purchaseOrderForm.getCartList()
+                .stream().map(productsCartForm -> ProductCartForm.convert(productsCartForm))
+                .collect(Collectors.toList()));
+
+        return  purchaseOrder;
     }
 }

--- a/src/main/java/br/com/meli/PIFrescos/controller/forms/PurchaseOrderForm.java
+++ b/src/main/java/br/com/meli/PIFrescos/controller/forms/PurchaseOrderForm.java
@@ -26,6 +26,13 @@ public class PurchaseOrderForm {
     @NotNull(message = "ProductsCart list field can't be empty")
     private List<ProductCartForm> cartList;
 
+    /**
+     * ConvertePurchaseOrderForm para PurchaseOrder.
+     * Diversos valores estarão nulos - serão tratados no serviço
+     * @param purchaseOrderForm
+     * @return purchseOrder
+     * @author Felipe Myose
+     */
     public static PurchaseOrder convertToEntity(PurchaseOrderForm purchaseOrderForm){
         User user = new User();
         user.setId(purchaseOrderForm.getUserId());

--- a/src/main/java/br/com/meli/PIFrescos/models/PurchaseOrder.java
+++ b/src/main/java/br/com/meli/PIFrescos/models/PurchaseOrder.java
@@ -25,6 +25,7 @@ public class PurchaseOrder {
     @ManyToOne
     private User user;
     private LocalDate date;
+    @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
     @OneToMany(cascade = CascadeType.ALL)
     private List<ProductsCart> cartList;

--- a/src/main/java/br/com/meli/PIFrescos/service/BatchServiceImpl.java
+++ b/src/main/java/br/com/meli/PIFrescos/service/BatchServiceImpl.java
@@ -5,15 +5,16 @@ import br.com.meli.PIFrescos.models.Batch;
 import br.com.meli.PIFrescos.repository.BatchRepository;
 import br.com.meli.PIFrescos.service.interfaces.IBatchService;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-@AllArgsConstructor
 public class BatchServiceImpl implements IBatchService {
 
-    private final BatchRepository batchRepository;
+    @Autowired
+    private BatchRepository batchRepository;
 
     /**
      *

--- a/src/main/java/br/com/meli/PIFrescos/service/PurchaseOrderService.java
+++ b/src/main/java/br/com/meli/PIFrescos/service/PurchaseOrderService.java
@@ -43,16 +43,16 @@ public class PurchaseOrderService implements IPurchaseOrderService {
     UserRepository userRepository;
 
     /**
-     * Salva uma PurchaseOrder. Antes de salvar, é verificado se a PurchaseOrder já existe.
+     * Salva uma PurchaseOrder. Antes de salvar, é necessário buscar informaçoes das entidades que o compõe.
      * @return PurchaseOrder
      * @author Ana Preis / Felipe Myose
      */
     @Override
     public PurchaseOrder save(PurchaseOrder purchaseOrder) {
         // purchaseOrder possui varios valores nulos devido ao payload que o user envia. popular estes valores
-        // encontrar o usuario:
+        // encontrar o usuario
         purchaseOrder.setUser(userRepository.findById(purchaseOrder.getUser().getId()).get());
-
+        //encontrar o batch
         List<ProductsCart> cartList = purchaseOrder.getCartList();
         cartList.forEach(productsCart -> {
             Integer batchNumber = productsCart.getBatch().getBatchNumber();

--- a/src/main/java/br/com/meli/PIFrescos/service/PurchaseOrderService.java
+++ b/src/main/java/br/com/meli/PIFrescos/service/PurchaseOrderService.java
@@ -6,6 +6,7 @@ import br.com.meli.PIFrescos.repository.BatchRepository;
 import br.com.meli.PIFrescos.repository.ProductRepository;
 
 import br.com.meli.PIFrescos.repository.PurchaseOrderRepository;
+import br.com.meli.PIFrescos.repository.UserRepository;
 import br.com.meli.PIFrescos.service.interfaces.IPurchaseOrderService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,17 +39,32 @@ public class PurchaseOrderService implements IPurchaseOrderService {
     @Autowired
     BatchRepository batchRepository;
 
+    @Autowired
+    UserRepository userRepository;
+
     /**
      * Salva uma PurchaseOrder. Antes de salvar, é verificado se a PurchaseOrder já existe.
      * @return PurchaseOrder
-     * @author Ana Preis
+     * @author Ana Preis / Felipe Myose
      */
     @Override
     public PurchaseOrder save(PurchaseOrder purchaseOrder) {
-        Optional<PurchaseOrder> purchaseOptional = purchaseOrderRepository.findById(purchaseOrder.getId());
-        if (purchaseOptional.isPresent()) {
-            throw new RuntimeException("PurchaseOrder already exists!");
-        }
+        // purchaseOrder possui varios valores nulos devido ao payload que o user envia. popular estes valores
+        // encontrar o usuario:
+        purchaseOrder.setUser(userRepository.findById(purchaseOrder.getUser().getId()).get());
+
+        List<ProductsCart> cartList = purchaseOrder.getCartList();
+        cartList.forEach(productsCart -> {
+            Integer batchNumber = productsCart.getBatch().getBatchNumber();
+            Batch batch = batchRepository.findByBatchNumber(batchNumber);
+            productsCart.setBatch(batch);
+        });
+
+        // comentando esta validaçao, pois como se trata de uma primeira compra, não há id do purchaseOrder - validar no put
+        //Optional<PurchaseOrder> purchaseOptional = purchaseOrderRepository.findById(purchaseOrder.getId());
+        //if (purchaseOptional.isPresent()) {
+        //    throw new RuntimeException("PurchaseOrder already exists!");
+        //}
 
         List<ProductsCart> invalidProductList = purchaseOrder.getCartList().stream()
                 .filter(productsCart -> batchRepository.existsBatchByBatchNumber(productsCart.getBatch().getBatchNumber()))

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,3 +1,5 @@
+INSERT INTO users(email, fullname, password, role) VALUES('email@email.com', 'name surname', '123456', 'BUYER');
+
 INSERT INTO warehouse(warehouse_code) VALUES(1);
 
 INSERT INTO section(current_capacity, max_capacity, storage_type, warehouse_warehouse_code) VALUES(0, 100, 'FRESH', 1);
@@ -28,11 +30,11 @@ INSERT INTO inbound_order(order_date, section_section_code) VALUES ('2022-04-25'
 
 -- batch
 -- FRESH
-INSERT INTO batch(current_temperature, minimum_temperature, initial_quantity, current_quantity, manufacturing_date, due_date, inbound_order_order_number, product_product_id) VALUES (15, 10, 5, 5, '2022-03-25', '2022-04-25', 1, 1);
+INSERT INTO batch(current_temperature, minimum_temperature, unit_price, initial_quantity, current_quantity, manufacturing_date, due_date, inbound_order_order_number, product_product_id) VALUES (15, 10, 2, 5, 5, '2022-03-25', '2022-04-25', 1, 1);
 -- REFRIGERATED
-INSERT INTO batch(current_temperature, minimum_temperature, initial_quantity, current_quantity, manufacturing_date, due_date, inbound_order_order_number, product_product_id) VALUES (10, 8, 5, 5, '2022-03-25', '2022-04-25', 2, 4);
+INSERT INTO batch(current_temperature, minimum_temperature, unit_price, initial_quantity, current_quantity, manufacturing_date, due_date, inbound_order_order_number, product_product_id) VALUES (10, 8, 2, 5, 5, '2022-03-25', '2022-04-25', 2, 4);
 -- FROZEN
-INSERT INTO batch(current_temperature, minimum_temperature, initial_quantity, current_quantity, manufacturing_date, due_date, inbound_order_order_number, product_product_id) VALUES (-15, -20, 5, 5, '2022-03-25', '2022-04-25', 3, 7);
+INSERT INTO batch(current_temperature, minimum_temperature, unit_price, initial_quantity, current_quantity, manufacturing_date, due_date, inbound_order_order_number, product_product_id) VALUES (-15, -20, 2, 5, 5, '2022-03-25', '2022-04-25', 3, 7);
 
 -- USERS
 INSERT INTO users(fullname, email, password) VALUES('Jose Alfredo', 'jose@gmail.com', '$2a$10$GtzVniP9dVMmVW2YxytuvOG9kHu9nrwAxe8/UXSFkaECmIJ4UJcHy');
@@ -50,3 +52,4 @@ INSERT INTO profile(name) VALUES('ADMIN');
 INSERT INTO users_profiles(user_id, profiles_id) VALUES(1, 1);
 INSERT INTO users_profiles(user_id, profiles_id) VALUES(2, 2);
 INSERT INTO users_profiles(user_id, profiles_id) VALUES(4, 4);
+

--- a/src/test/java/br/com/meli/PIFrescos/service/PurchaseOrderServiceTest.java
+++ b/src/test/java/br/com/meli/PIFrescos/service/PurchaseOrderServiceTest.java
@@ -4,6 +4,7 @@ import br.com.meli.PIFrescos.config.handler.ProductCartException;
 import br.com.meli.PIFrescos.models.*;
 import br.com.meli.PIFrescos.repository.BatchRepository;
 import br.com.meli.PIFrescos.repository.PurchaseOrderRepository;
+import br.com.meli.PIFrescos.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,9 @@ import static org.mockito.Mockito.verify;
 public class PurchaseOrderServiceTest {
 
     @Mock
+    UserRepository userRepository;
+
+    @Mock
     PurchaseOrderRepository purchaseOrderRepository;
 
     @Mock
@@ -52,9 +56,12 @@ public class PurchaseOrderServiceTest {
     private ProductsCart productsCart1 = new ProductsCart();
     private ProductsCart productsCart2 = new ProductsCart();
     private List<PurchaseOrder> purchaseOrderList = new ArrayList<>();
+    private User user1 = new User();
 
     @BeforeEach
     void setup() {
+        user1.setId(1);
+
         product1.setProductId(1);
         product1.setProductName("Banana");
         product1.setProductType(FRESH);
@@ -104,7 +111,7 @@ public class PurchaseOrderServiceTest {
         Mockito.when(batchRepository.existsBatchByBatchNumber(any())).thenReturn(true);
         Mockito.when(batchRepository.findByBatchNumber(1)).thenReturn(mockBatch1);
         Mockito.when(batchRepository.findByBatchNumber(2)).thenReturn(mockBatch2);
-
+        Mockito.when(userRepository.findById(purchaseOrder.getUser().getId())).thenReturn(Optional.ofNullable(user1));
         PurchaseOrder savedPurchaseOrder = purchaseOrderService.save(purchaseOrder);
 
         assertEquals(purchaseOrder, savedPurchaseOrder);

--- a/src/test/java/br/com/meli/PIFrescos/service/PurchaseOrderServiceTest.java
+++ b/src/test/java/br/com/meli/PIFrescos/service/PurchaseOrderServiceTest.java
@@ -96,7 +96,7 @@ public class PurchaseOrderServiceTest {
         productsCartList = Arrays.asList(productsCart1, productsCart2);
 
         purchaseOrder.setId(1);
-        purchaseOrder.setUser(new User());
+        purchaseOrder.setUser(user1);
         purchaseOrder.setDate(LocalDate.of(2022, 1, 8));
         purchaseOrder.setOrderStatus(OPENED);
         purchaseOrder.setCartList(productsCartList);
@@ -107,7 +107,7 @@ public class PurchaseOrderServiceTest {
     @Test
     void shouldSavePurchaseOrder(){
         Mockito.when(purchaseOrderRepository.save(purchaseOrder)).thenReturn(purchaseOrder);
-        Mockito.when(purchaseOrderRepository.findById(purchaseOrder.getId())).thenReturn(Optional.empty());
+        //Mockito.when(purchaseOrderRepository.findById(purchaseOrder.getId())).thenReturn(Optional.empty());
         Mockito.when(batchRepository.existsBatchByBatchNumber(any())).thenReturn(true);
         Mockito.when(batchRepository.findByBatchNumber(1)).thenReturn(mockBatch1);
         Mockito.when(batchRepository.findByBatchNumber(2)).thenReturn(mockBatch2);
@@ -120,24 +120,14 @@ public class PurchaseOrderServiceTest {
     @Test
     void shouldNotValidatePurchaseOrder(){
         productsCart1.setBatch(mockBatch3);
-        Mockito.when(purchaseOrderRepository.findById(purchaseOrder.getId())).thenReturn(Optional.empty());
         Mockito.when(batchRepository.existsBatchByBatchNumber(any())).thenReturn(true);
         Mockito.when(batchRepository.findByBatchNumber(3)).thenReturn(mockBatch3);
         Mockito.when(batchRepository.findByBatchNumber(2)).thenReturn(mockBatch2);
+        Mockito.when(userRepository.findById(purchaseOrder.getUser().getId())).thenReturn(Optional.ofNullable(user1));
 
         ProductCartException exception = Assertions.assertThrows(ProductCartException.class, () -> purchaseOrderService.save(purchaseOrder));
 
         assertEquals(exception.getErrorFormsDtoList().size(),1);
-    }
-
-    @Test
-    void shouldNotSavePurchaseOrder(){
-        String message = "PurchaseOrder already exists!";
-        Mockito.when(purchaseOrderRepository.findById(purchaseOrder.getId())).thenReturn(Optional.ofNullable(purchaseOrder));
-
-        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> purchaseOrderService.save(purchaseOrder));
-
-        assertThat(exception.getMessage()).isEqualTo(message);
     }
 
     @Test


### PR DESCRIPTION
- udpate test cases
- udpate docs
- Update save method from PurchaseOrderService to retrieve the
information of required purchase.
PurchaseOrder post payload example:
```
{
        "userId": 1,
        "orderStatus": "OPENED",
        "cartList": [
            {
                "batchId": 1,
                "quantity": 5
            },
            {
                "batchId": 2,
                "quantity": 3
            }
        ]
}
```

