### PR TITLE
refact: replace repository instances by service

### DIFF
--- a/src/main/java/br/com/meli/PIFrescos/service/BatchServiceImpl.java
+++ b/src/main/java/br/com/meli/PIFrescos/service/BatchServiceImpl.java
@@ -55,6 +55,11 @@ public class BatchServiceImpl implements IBatchService {
         return batchRepository.findById(id).orElseThrow(() -> new RuntimeException("Not Found"));
     }
 
+    @Override
+    public Batch findByBatchNumber(Integer id) {
+        return batchRepository.findByBatchNumber(id);
+    }
+
     /**
      * @param productId  id do produto
      * @return List<Batch>

--- a/src/main/java/br/com/meli/PIFrescos/service/PurchaseOrderService.java
+++ b/src/main/java/br/com/meli/PIFrescos/service/PurchaseOrderService.java
@@ -2,12 +2,9 @@ package br.com.meli.PIFrescos.service;
 
 import br.com.meli.PIFrescos.models.*;
 import br.com.meli.PIFrescos.config.handler.ProductCartException;
-import br.com.meli.PIFrescos.repository.BatchRepository;
-import br.com.meli.PIFrescos.repository.ProductRepository;
 
 import br.com.meli.PIFrescos.repository.PurchaseOrderRepository;
 import br.com.meli.PIFrescos.service.interfaces.IBatchService;
-import br.com.meli.PIFrescos.repository.UserRepository;
 import br.com.meli.PIFrescos.service.interfaces.IPurchaseOrderService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,16 +28,7 @@ public class PurchaseOrderService implements IPurchaseOrderService {
     PurchaseOrderRepository purchaseOrderRepository;
 
     @Autowired
-    ProductRepository productRepository;
-
-    @Autowired
-    BatchRepository batchRepository;
-
-    @Autowired
     IBatchService batchService;
-
-    @Autowired
-    UserRepository userRepository;
 
     /**
      * Salva uma PurchaseOrder. Antes de salvar, é necessário buscar informaçoes das entidades que o compõe.
@@ -60,7 +48,7 @@ public class PurchaseOrderService implements IPurchaseOrderService {
         //encontrar o batch
         purchaseOrder.getCartList().forEach(productsCart -> {
             Integer batchNumber = productsCart.getBatch().getBatchNumber();
-            Batch batch = batchRepository.findByBatchNumber(batchNumber);
+            Batch batch = batchService.findByBatchNumber(batchNumber);
             productsCart.setBatch(batch);
         });
         validProductList(purchaseOrder);
@@ -85,7 +73,7 @@ public class PurchaseOrderService implements IPurchaseOrderService {
     @Override
     public boolean isProductsCartListQuantityValid(ProductsCart productsCart){
         Integer productCartQuantity = productsCart.getQuantity();
-        Batch batch = batchRepository.findByBatchNumber(productsCart.getBatch().getBatchNumber());
+        Batch batch = batchService.findByBatchNumber(productsCart.getBatch().getBatchNumber());
         Integer batchCurrentQuantity = batch.getCurrentQuantity();
 
         boolean isValid = batchCurrentQuantity.compareTo(productCartQuantity) > 0;

--- a/src/main/java/br/com/meli/PIFrescos/service/interfaces/IBatchService.java
+++ b/src/main/java/br/com/meli/PIFrescos/service/interfaces/IBatchService.java
@@ -8,6 +8,7 @@ import java.util.List;
 public interface IBatchService {
 
     Batch findBatchById(Integer id);
+    Batch findByBatchNumber(Integer id);
     List<Batch> findBatchesByProduct(Integer productId);
     boolean checkIfBatchExists(Batch batch);
     Batch updateCurrentQuantity(Integer quantity, Batch batch);

--- a/src/test/java/br/com/meli/PIFrescos/service/PurchaseOrderServiceTest.java
+++ b/src/test/java/br/com/meli/PIFrescos/service/PurchaseOrderServiceTest.java
@@ -2,11 +2,8 @@ package br.com.meli.PIFrescos.service;
 
 import br.com.meli.PIFrescos.config.handler.ProductCartException;
 import br.com.meli.PIFrescos.models.*;
-import br.com.meli.PIFrescos.repository.BatchRepository;
 import br.com.meli.PIFrescos.repository.PurchaseOrderRepository;
 import br.com.meli.PIFrescos.service.interfaces.IBatchService;
-import br.com.meli.PIFrescos.repository.UserRepository;
-import br.com.meli.PIFrescos.service.interfaces.IPurchaseOrderService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static br.com.meli.PIFrescos.models.OrderStatus.FINISHED;
 import static br.com.meli.PIFrescos.models.OrderStatus.OPENED;
 import static br.com.meli.PIFrescos.models.StorageType.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,13 +34,7 @@ import static org.mockito.Mockito.verify;
 public class PurchaseOrderServiceTest {
 
     @Mock
-    UserRepository userRepository;
-
-    @Mock
     PurchaseOrderRepository purchaseOrderRepository;
-
-    @Mock
-    BatchRepository batchRepository;
 
     @Mock
     IBatchService batchService;
@@ -125,10 +115,8 @@ public class PurchaseOrderServiceTest {
     @Test
     void shouldSavePurchaseOrder(){
         Mockito.when(purchaseOrderRepository.save(purchaseOrder)).thenReturn(purchaseOrder);
-        Mockito.lenient().when(batchRepository.existsBatchByBatchNumber(any())).thenReturn(true);
-        Mockito.lenient().when(batchRepository.findByBatchNumber(1)).thenReturn(mockBatch1);
-        Mockito.lenient().when(batchRepository.findByBatchNumber(2)).thenReturn(mockBatch2);
-        Mockito.lenient().when(userRepository.findById(purchaseOrder.getUser().getId())).thenReturn(Optional.ofNullable(user1));
+        Mockito.lenient().when(batchService.findByBatchNumber(1)).thenReturn(mockBatch1);
+        Mockito.lenient().when(batchService.findByBatchNumber(2)).thenReturn(mockBatch2);
         PurchaseOrder savedPurchaseOrder = purchaseOrderService.save(purchaseOrder);
 
         assertEquals(purchaseOrder, savedPurchaseOrder);
@@ -138,8 +126,8 @@ public class PurchaseOrderServiceTest {
     void shouldSavePurchaseOrderWhenUserAlreadyHasAnOrder(){
         Mockito.when(purchaseOrderRepository.getPurchaseOpenedByUserId(any())).thenReturn(Collections.singletonList(purchaseOrder));
         Mockito.when(purchaseOrderRepository.save(purchaseOrder)).thenReturn(purchaseOrder);
-        Mockito.when(batchRepository.findByBatchNumber(1)).thenReturn(mockBatch1);
-        Mockito.when(batchRepository.findByBatchNumber(2)).thenReturn(mockBatch2);
+        Mockito.when(batchService.findByBatchNumber(1)).thenReturn(mockBatch1);
+        Mockito.when(batchService.findByBatchNumber(2)).thenReturn(mockBatch2);
         PurchaseOrder savedPurchaseOrder = purchaseOrderService.save(purchaseOrder);
 
         assertEquals(purchaseOrder, savedPurchaseOrder);
@@ -153,10 +141,8 @@ public class PurchaseOrderServiceTest {
     @Test
     void shouldNotValidatePurchaseOrder(){
         productsCart1.setBatch(mockBatch3);
-        Mockito.lenient().when(batchRepository.existsBatchByBatchNumber(any())).thenReturn(true);
-        Mockito.lenient().when(batchRepository.findByBatchNumber(3)).thenReturn(mockBatch3);
-        Mockito.lenient().when(batchRepository.findByBatchNumber(2)).thenReturn(mockBatch2);
-        Mockito.lenient().when(userRepository.findById(purchaseOrder.getUser().getId())).thenReturn(Optional.ofNullable(user1));
+        Mockito.lenient().when(batchService.findByBatchNumber(3)).thenReturn(mockBatch3);
+        Mockito.lenient().when(batchService.findByBatchNumber(2)).thenReturn(mockBatch2);
 
         ProductCartException exception = Assertions.assertThrows(ProductCartException.class, () -> purchaseOrderService.save(purchaseOrder));
 
@@ -320,8 +306,8 @@ public class PurchaseOrderServiceTest {
         productsCart1.setQuantity(3);
         productsCart2.setQuantity(3);
 
-        Mockito.when(batchRepository.findByBatchNumber(1)).thenReturn(mockBatch1);
-        Mockito.when(batchRepository.findByBatchNumber(2)).thenReturn(mockBatch2);
+        Mockito.when(batchService.findByBatchNumber(1)).thenReturn(mockBatch1);
+        Mockito.when(batchService.findByBatchNumber(2)).thenReturn(mockBatch2);
         Mockito.when(purchaseOrderRepository.save(purchaseOrder)).thenReturn(purchaseOrder);
 
         PurchaseOrder result = purchaseOrderService.updateCartList(purchaseOrder);


### PR DESCRIPTION
Some services were injecting repository from external service. Instead,
make it to use the service that owns that repository.